### PR TITLE
Rewrite iterators to not duplicate code

### DIFF
--- a/utils/basicString.hpp
+++ b/utils/basicString.hpp
@@ -385,7 +385,8 @@ namespace dex
 			template < bool isConst, bool isForward >
 			void swap( _iterator < isConst, isForward > &a, _iterator < isConst, isForward > &b )
 				{
-				dex::swap( a, b );
+				dex::swap( a.string, b.string );
+				dex::swap( a.position, b.position );
 				}
 		public:
 			typedef _iterator < false, true > iterator;


### PR DESCRIPTION
jasina
Use std::conditional and std::enable_if to make a single "master"
iterator type. From there, this is templated into each of the four
public-facing iterator types.